### PR TITLE
Add format-spec requirement

### DIFF
--- a/keycast.el
+++ b/keycast.el
@@ -29,6 +29,9 @@
 ;; and updates them whenever another command is invoked.
 
 ;;; Code:
+
+(require 'format-spec)
+
 ;;; Options
 
 (defgroup keycast nil


### PR DESCRIPTION
Add format-spec dependency. keycast-mode fails without it at least on Emacs 27.1:

```
Keycast mode enabled
Error during redisplay: (eval (and (funcall keycast-window-predicate) (not keycast--reading-passwd) (let* ((key (ignore-errors (key-description keycast--this-command-keys))) (cmd keycast--this-command) (elt (or (assoc cmd keycast-substitute-alist) (assoc key keycast-substitute-alist)))) (when elt (pcase-let ((`(,_ ,k ,c) elt)) (unless (eq k t) (setq key k)) (unless (eq c t) (setq cmd c)))) (and key cmd (let ((k (let ((pad (max 2 (- 5 (length key))))) (concat (make-string (ceiling pad 2) 32) key (make-string (floor pad 2) 32)))) (c (format " %s" cmd))) (format-spec mode-line-keycast-format `((115 \, (make-string keycast-separator-width 32)) (107 \, (propertize k 'face 'keycast-key)) (75 \, k) (99 \, (propertize c 'face 'keycast-command)) (67 \, c) (114 \, (if (> keycast--command-repetitions 0) (format " x%s" (1+ keycast--command-repetitions)) ""))))))))) signaled (void-function format-spec) [7 times]
```