### PR TITLE
keycast--update: Update mode line in minibuffers

### DIFF
--- a/keycast.el
+++ b/keycast.el
@@ -32,6 +32,10 @@
 
 (require 'format-spec)
 
+(eval-when-compile
+  (require 'cl-lib)
+  (require 'subr-x))
+
 ;;; Options
 
 (defgroup keycast nil

--- a/keycast.el
+++ b/keycast.el
@@ -220,7 +220,14 @@ instead."
   (when keycast-log-mode
     (keycast-log-update-buffer))
   (when keycast-mode
-    (force-mode-line-update)))
+    ;; Mode line isn't updated for minibuffers, so try to do so from
+    ;; the window that activated it, falling back to no buffer change.
+    (if-let ((win (and (minibufferp)
+                       (minibuffer-selected-window)))
+             (buf (window-buffer win)))
+        (with-current-buffer buf
+          (force-mode-line-update))
+      (force-mode-line-update))))
 
 (defun keycast--format (format)
   (and (not keycast--reading-passwd)


### PR DESCRIPTION
The `keycast` mode line doesn't reflect keys typed in the minibuffer, for example:

1. `emacs -Q -l keycast.elc -f keycast-mode`
2. `C-p`
   Mode line shows `[ C-p ] previous-line`.
3. `C-x C-f`
   Mode line shows `[ C-x C-f ] find-file`.
4. `C-b`
   Mode line still shows `[ C-x C-f ] find-file`.

The `C-b` still results in `keycast--update` being called, but `force-mode-line-update` seems to have no effect when the current buffer is a minibuffer (makes sense considering mini-windows lack a mode line).

Assuming this behaviour is not by design, this PR addresses it by calling `force-mode-line-update` from the buffer of the window that activated the minibuffer (when applicable).

Something similar is done in `eldoc-minibuffer-message`, although that also checks `window-in-direction` and `get-largest-window` in addition to `minibuffer-selected-window`.  I'm not sure that's needed in this case.

If OTOH the current behaviour is by design, would a user option to control this be acceptable?

Thanks.

---

P.S. The first commit loads a couple of dependencies because `cl-incf`, `when-let`, et al. weren't autoloaded pre-Emacs 27.

---

P.P.S. The PR template still talks about how to update the Magit manual :).