### PR TITLE
keycast-log-update-buffer: respect repetition for more concise log.

### DIFF
--- a/keycast.el
+++ b/keycast.el
@@ -153,7 +153,7 @@ instead."
                         (const   :tag "Use actual command" t)
                         (symbol  :tag "Substitute command")))))
 
-(defcustom keycast-log-format "%-20K%C\n"
+(defcustom keycast-log-format "%-20K%C%r\n"
   "The format spec used by `keycast-log-mode'.
 
 %s `keycast-separator-width' spaces.
@@ -351,7 +351,17 @@ instead."
             (switch-to-buffer-other-frame (current-buffer)))))
       (with-current-buffer buf
         (goto-char (if keycast-log-newest-first (point-min) (point-max)))
-        (let ((inhibit-read-only t))
+        (let ((inhibit-read-only t)
+              (case-fold-search nil))
+          ;; delete the previous log if it's repeated
+          (when (and (string-match "%r" keycast-log-format)
+                     (> keycast--command-repetitions 0))
+            (when (and (not keycast-log-newest-first)
+                       (> (point) (point-min)))
+              (previous-line))
+            (delete-region
+             (line-beginning-position)
+             (1+ (line-end-position))))
           (when-let ((output (keycast--format keycast-log-format)))
             (insert output)))
         (goto-char (if keycast-log-newest-first (point-min) (point-max)))))))

--- a/keycast.el
+++ b/keycast.el
@@ -353,16 +353,16 @@ instead."
         (goto-char (if keycast-log-newest-first (point-min) (point-max)))
         (let ((inhibit-read-only t)
               (case-fold-search nil))
-          ;; delete the previous log if it's repeated
-          (when (and (string-match "%r" keycast-log-format)
-                     (> keycast--command-repetitions 0))
-            (when (and (not keycast-log-newest-first)
-                       (> (point) (point-min)))
-              (previous-line))
-            (delete-region
-             (line-beginning-position)
-             (1+ (line-end-position))))
           (when-let ((output (keycast--format keycast-log-format)))
+            ;; delete the previous log if it's repeated
+            (when (and (string-match "%r" keycast-log-format)
+                       (> keycast--command-repetitions 0))
+              (when (and (not keycast-log-newest-first)
+                         (> (point) (point-min)))
+                (previous-line))
+              (delete-region
+               (line-beginning-position)
+               (1+ (line-end-position))))
             (insert output)))
         (goto-char (if keycast-log-newest-first (point-min) (point-max)))))))
 


### PR DESCRIPTION
What you should write here
=================================================================

I noticed that there is a neat repetition indicator on the mode line, but the dedicated log buffer lacks this, so it's a little verbose if there are many repeated commands.

This PR tries to fix that.

How to update the manual
=================================================================

NA.
