### PR TITLE
Minor fixes: mismatch type and several "instances" of keycast

### DIFF
--- a/keycast.el
+++ b/keycast.el
@@ -64,12 +64,11 @@ Enabling `keycast-mode-line-mode' inserts the element
 `keycast-mode-line' into `mode-line-format' after the
 element specified here."
   :group 'keycast
-  :type '(cons (choice :tag "Insert after"
-                       (const mode-line-buffer-identification)
-                       (const moody-mode-line-buffer-identification)
-                       variable
-                       sexp)
-               (boolean :tag "Remove following elements")))
+  :type '(choice :tag "Insert after"
+                 (const mode-line-buffer-identification)
+                 (const moody-mode-line-buffer-identification)
+                 variable
+                 sexp))
 
 (defcustom keycast-mode-line-remove-tail-elements t
   "Whether enabling `keycast-mode-line-mode' removes elements to the right.
@@ -135,10 +134,10 @@ Enabling `keycast-header-line-mode' inserts the element
 `keycast-header-line' into `header-line-format' after the
 element specified here."
   :group 'keycast
-  :type '(cons (choice :tag "Insert after"
-                       variable
-                       sexp)
-               (boolean :tag "Remove following elements")))
+  :type '(choice :tag "Insert after"
+                 string
+                 variable
+                 sexp))
 
 (defcustom keycast-header-line-remove-tail-elements t
   "Whether enabling `keycast-header-line-mode' removes elements to the right.

--- a/keycast.el
+++ b/keycast.el
@@ -496,7 +496,7 @@ t to show the actual COMMAND, or a symbol to be shown instead."
              (setq keycast--mode-line-removed-tail (cdr cons))
              (setcdr cons (list 'keycast-mode-line)))
             (t
-             (setcdr cons (cons 'keycast-mode-line (cdr cons)))))
+             (setcdr cons (cl-pushnew 'keycast-mode-line (cdr cons)))))
       (add-hook 'post-command-hook #'keycast--update t)
       (add-hook 'minibuffer-exit-hook #'keycast--minibuffer-exit t)))
    (t
@@ -558,7 +558,7 @@ t to show the actual COMMAND, or a symbol to be shown instead."
              (setq keycast--header-line-removed-tail (cdr cons))
              (setcdr cons (list 'keycast-header-line)))
             (t
-             (setcdr cons (cons 'keycast-header-line (cdr cons)))))
+             (setcdr cons (cl-pushnew 'keycast-header-line (cdr cons)))))
       (add-hook 'post-command-hook #'keycast--update t)
       (add-hook 'minibuffer-exit-hook #'keycast--minibuffer-exit t)))
    (t
@@ -624,7 +624,7 @@ t to show the actual COMMAND, or a symbol to be shown instead."
       (t
        (let ((mem (memq keycast-tab-bar-location tab-bar-format)))
          (if mem
-             (setcdr mem (cons 'keycast-tab-bar (cdr mem)))
+             (setcdr mem (cl-pushnew 'keycast-tab-bar (cdr mem)))
            (setq tab-bar-format
                  (nconc tab-bar-format
                         (if (eq keycast-tab-bar-location


### PR DESCRIPTION
Hello @tarsius, thank you in advance for all your work.

Recently when trying `setopt` a type mismatch was flagged on one of the variables. The first commit addresses that issue. I took the liberty to also delete the boolean from the initial cons type, since it seems that the `defcustom keycast-...-remove-tail-elements` now serves that purpose.

Furthermore, for each evaluation of `(keycast-mode 1)` the package would produce another "instance" of keycast. The second commit takes care of that part.

Again, thanks for sharing. Best regards,
Bruno Boal
