### PR TITLE
Indirect command loop

### DIFF
--- a/keycast.el
+++ b/keycast.el
@@ -469,6 +469,10 @@ t to show the actual COMMAND, or a symbol to be shown instead."
   (add-hook 'post-command-hook #'keycast--update t)
   (add-hook 'minibuffer-exit-hook #'keycast--minibuffer-exit t))
 
+(defun keycast--remove-hooks ()
+  (remove-hook 'post-command-hook #'keycast--update)
+  (remove-hook 'minibuffer-exit-hook #'keycast--minibuffer-exit))
+
 ;;; Mode-Line
 
 (defvar keycast--mode-line-removed-tail nil)
@@ -522,8 +526,7 @@ t to show the actual COMMAND, or a symbol to be shown instead."
           (setq-local mode-line-format
                       (delq 'keycast-mode-line mode-line-format)))))
     (unless (keycast--mode-active-p)
-      (remove-hook 'post-command-hook #'keycast--update)
-      (remove-hook 'minibuffer-exit-hook #'keycast--minibuffer-exit)))))
+      (keycast--remove-hooks)))))
 
 (defvar keycast-mode-line
   '(:eval
@@ -585,8 +588,7 @@ t to show the actual COMMAND, or a symbol to be shown instead."
             (setq header-line-format
                   (delq 'keycast-header-line header-line-format))))))
     (unless (keycast--mode-active-p)
-      (remove-hook 'post-command-hook #'keycast--update)
-      (remove-hook 'minibuffer-exit-hook #'keycast--minibuffer-exit)))))
+      (keycast--remove-hooks)))))
 
 (defvar keycast-header-line
   '(:eval
@@ -649,8 +651,7 @@ t to show the actual COMMAND, or a symbol to be shown instead."
           (t
            (setq tab-bar-format (delq 'keycast-tab-bar tab-bar-format))))
     (unless (keycast--mode-active-p)
-      (remove-hook 'post-command-hook #'keycast--update)
-      (remove-hook 'minibuffer-exit-hook #'keycast--minibuffer-exit)))))
+      (keycast--remove-hooks)))))
 
 (defun keycast-tab-bar ()
   "Produce key binding information for the tab bar."
@@ -674,8 +675,7 @@ t to show the actual COMMAND, or a symbol to be shown instead."
     (keycast-log--set-focus-properties t)
     (keycast-log-update-buffer))
    ((not (keycast--mode-active-p))
-    (remove-hook 'post-command-hook #'keycast--update)
-    (remove-hook 'minibuffer-exit-hook #'keycast--minibuffer-exit)
+    (keycast--remove-hooks)
     (keycast-log--set-focus-properties nil))))
 
 (defun keycast-log-update-buffer ()

--- a/keycast.el
+++ b/keycast.el
@@ -350,7 +350,8 @@ t to show the actual COMMAND, or a symbol to be shown instead."
 
 (defun keycast--update ()
   (let ((key (this-single-command-keys))
-        (cmd this-command))
+        (cmd (if (eq this-command keycast--pre-command) this-command
+               keycast--pre-command)))
     (when (and keycast--minibuffer-exited
                (or (not (equal key []))
                    (not (eq this-original-command 'execute-extended-command))))

--- a/keycast.el
+++ b/keycast.el
@@ -334,6 +334,7 @@ t to show the actual COMMAND, or a symbol to be shown instead."
 (defvar keycast--minibuffer-exited nil)
 (defvar keycast--command-repetitions 0)
 (defvar keycast--reading-passwd nil)
+(defvar keycast--pre-command nil)
 
 (defun keycast--minibuffer-exit ()
   (setq keycast--minibuffer-exited
@@ -343,6 +344,9 @@ t to show the actual COMMAND, or a symbol to be shown instead."
   ;; at least the command that exited the minibuffer was used
   ;; in between (but `last-command' doesn't account for that).
   (setq keycast--command-repetitions -2))
+
+(defun keycast--pre-command-record ()
+  (setq keycast--pre-command this-command))
 
 (defun keycast--update ()
   (let ((key (this-single-command-keys))
@@ -466,10 +470,12 @@ t to show the actual COMMAND, or a symbol to be shown instead."
                  (throw 'found found)))))))
 
 (defun keycast--add-hooks ()
+  (add-hook 'pre-command-hook #'keycast--pre-command-record t)
   (add-hook 'post-command-hook #'keycast--update t)
   (add-hook 'minibuffer-exit-hook #'keycast--minibuffer-exit t))
 
 (defun keycast--remove-hooks ()
+  (remove-hook 'pre-command-hook #'keycast--pre-command-record t)
   (remove-hook 'post-command-hook #'keycast--update)
   (remove-hook 'minibuffer-exit-hook #'keycast--minibuffer-exit))
 

--- a/keycast.el
+++ b/keycast.el
@@ -465,6 +465,10 @@ t to show the actual COMMAND, or a symbol to be shown instead."
                (when-let ((found (keycast--tree-member elt sub)))
                  (throw 'found found)))))))
 
+(defun keycast--add-hooks ()
+  (add-hook 'post-command-hook #'keycast--update t)
+  (add-hook 'minibuffer-exit-hook #'keycast--minibuffer-exit t))
+
 ;;; Mode-Line
 
 (defvar keycast--mode-line-removed-tail nil)
@@ -497,8 +501,8 @@ t to show the actual COMMAND, or a symbol to be shown instead."
              (setcdr cons (list 'keycast-mode-line)))
             (t
              (setcdr cons (cl-pushnew 'keycast-mode-line (cdr cons)))))
-      (add-hook 'post-command-hook #'keycast--update t)
-      (add-hook 'minibuffer-exit-hook #'keycast--minibuffer-exit t)))
+      (keycast--add-hooks)))
+
    (t
     (let ((cons (keycast--tree-member 'keycast-mode-line
                                       (default-value 'mode-line-format))))
@@ -559,8 +563,8 @@ t to show the actual COMMAND, or a symbol to be shown instead."
              (setcdr cons (list 'keycast-header-line)))
             (t
              (setcdr cons (cl-pushnew 'keycast-header-line (cdr cons)))))
-      (add-hook 'post-command-hook #'keycast--update t)
-      (add-hook 'minibuffer-exit-hook #'keycast--minibuffer-exit t)))
+      (keycast--add-hooks)))
+
    (t
     (let ((cons (keycast--tree-member 'keycast-header-line
                                       (default-value 'header-line-format))))
@@ -634,8 +638,7 @@ t to show the actual COMMAND, or a symbol to be shown instead."
                           (message "%s not found in %s; adding at end instead"
                                    keycast-tab-bar-location 'tab-bar-format)
                           (list 'keycast-tab-bar))))))))
-    (add-hook 'post-command-hook #'keycast--update t)
-    (add-hook 'minibuffer-exit-hook #'keycast--minibuffer-exit t))
+    (keycast--add-hooks))
    (t
     (when keycast--temporary-tab-bar
       (setq keycast--temporary-tab-bar nil)
@@ -667,8 +670,7 @@ t to show the actual COMMAND, or a symbol to be shown instead."
   :global t
   (cond
    (keycast-log-mode
-    (add-hook 'post-command-hook #'keycast--update t)
-    (add-hook 'minibuffer-exit-hook #'keycast--minibuffer-exit t)
+    (keycast--add-hooks)
     (keycast-log--set-focus-properties t)
     (keycast-log-update-buffer))
    ((not (keycast--mode-active-p))


### PR DESCRIPTION
This is the simplest version of avoiding showing garbage for commands like M-x that revert `this-command` before the post-command-hook.

This is basically what people want, to see `next-line` when running `M-x next-line RET` instead of `ivy-done` etc.

If you filter M-x, then you would never see this, but it still comes up in other places.